### PR TITLE
fix: 修复<bind>标签定义变量不生效的问题

### DIFF
--- a/sql-analysis/src/main/java/com/jd/sql/analysis/extract/SqlExtract.java
+++ b/sql-analysis/src/main/java/com/jd/sql/analysis/extract/SqlExtract.java
@@ -156,12 +156,12 @@ public class SqlExtract {
                 MetaObject metaObject = configuration.newMetaObject(parameterObject);
                 for (ParameterMapping parameterMapping : parameterMappings) {
                     String propertyName = parameterMapping.getProperty();
-                    if (metaObject.hasGetter(propertyName)) {
-                        Object obj = metaObject.getValue(propertyName);
-                        sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(getParameterValue(obj)));
-                    } else if (boundSql.hasAdditionalParameter(propertyName)) {
+                    if (boundSql.hasAdditionalParameter(propertyName)) {
                         // 该分支是动态sql
                         Object obj = boundSql.getAdditionalParameter(propertyName);
+                        sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(getParameterValue(obj)));
+                    } else if (metaObject.hasGetter(propertyName)) {
+                        Object obj = metaObject.getValue(propertyName);
                         sql = sql.replaceFirst("\\?", Matcher.quoteReplacement(getParameterValue(obj)));
                     } else {
                         // 打印出缺失，提醒该参数缺失并防止错位


### PR DESCRIPTION
mybatis对于< bind >标签中定义的变量的使用优先级是最高的，所以这里应该先去读取additionalParameters中变量，读不到再去读取parameterObject。源码中优先级情况如下图所示：
![image](https://github.com/jd-opensource/sql-analysis/assets/52639470/b7f03a34-f739-4149-893e-fd80c0a6029e)

复现条件：
    在源码中所给的案例中，TaskMapper.xml中的queryAll中加入< bind name="createUser" value="createUser + 'lalala'"/ >即可复现，此时在com.jd.sql.analysis.extract.SqlExtract#showSql中拿到的变量值依然是参数对象中的zhangsan1而不是< bind >标签中定义的zhangsan1lalala